### PR TITLE
feat: Add UsersChart widget and integrate laravel-trend package

### DIFF
--- a/app/Filament/Resources/QuestionResource.php
+++ b/app/Filament/Resources/QuestionResource.php
@@ -82,7 +82,7 @@ class QuestionResource extends Resource
     public static function getRelations(): array
     {
         return [
-            ChoicesRelationManager::class,
+            //ChoicesRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/TestResource.php
+++ b/app/Filament/Resources/TestResource.php
@@ -105,7 +105,7 @@ class TestResource extends Resource
     public static function getRelations(): array
     {
         return [
-            QuestionsRelationManager::class,
+            //QuestionsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Widgets/UsersChart.php
+++ b/app/Filament/Widgets/UsersChart.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\User;
+use Flowframe\Trend\Trend;
+use Flowframe\Trend\TrendValue;
+use Filament\Widgets\ChartWidget;
+
+class UsersChart extends ChartWidget
+{
+    protected static ?string $heading = 'Users';
+    protected static ?string $description = 'Users Chart';
+
+    protected function getData(): array
+    {
+        $data = Trend::model(User::class)
+        ->between(
+            start: now()->startOfYear(),
+            end: now()->endOfYear(),
+        )
+        ->perMonth()
+        ->count();
+ 
+    return [
+        'datasets' => [
+            [
+                'label' => 'Users',
+                'data' => $data->map(fn (TrendValue $value) => $value->aggregate),
+            ],
+        ],
+        'labels' => $data->map(fn (TrendValue $value) => $value->date),
+    ];
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -50,7 +50,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([
-                Widgets\AccountWidget::class,
+                
                 SystemStats::class,
             ])
             ->middleware([

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "bezhansalleh/filament-language-switch": "^3.1",
         "bezhansalleh/filament-shield": "^3.3",
         "filament/filament": "^3.2",
+        "flowframe/laravel-trend": "^0.4.0",
         "hugomyb/filament-media-action": "v3.1.1.7",
         "laravel/framework": "^11.31",
         "laravel/tinker": "^2.9"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b167d7bab427bf861d56b3604dc67e2",
+    "content-hash": "10fe187266390ecc58e93edb2f505860",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -1575,6 +1575,80 @@
                 "source": "https://github.com/filamentphp/filament"
             },
             "time": "2025-02-19T08:42:37+00:00"
+        },
+        {
+            "name": "flowframe/laravel-trend",
+            "version": "v0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Flowframe/laravel-trend.git",
+                "reference": "5ace11d3075932652dc48963faa732c043aeb14d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Flowframe/laravel-trend/zipball/5ace11d3075932652dc48963faa732c043aeb14d",
+                "reference": "5ace11d3075932652dc48963faa732c043aeb14d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^8.37|^9|^10.0|^11.0|^12.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.4.3"
+            },
+            "require-dev": {
+                "nunomaduro/collision": "^5.3|^6.1|^8.0",
+                "orchestra/testbench": "^6.15|^7.0|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.18|^2.34|^3.7",
+                "pestphp/pest-plugin-laravel": "^1.1|^2.3|^3.1",
+                "spatie/laravel-ray": "^1.23",
+                "vimeo/psalm": "^4.8|^5.6|^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Trend": "Flowframe\\Trend\\TrendFacade"
+                    },
+                    "providers": [
+                        "Flowframe\\Trend\\TrendServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Flowframe\\Trend\\": "src",
+                    "Flowframe\\Trend\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Klopstra",
+                    "email": "lars@flowframe.nl",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily generate model trends",
+            "homepage": "https://github.com/flowframe/laravel-trend",
+            "keywords": [
+                "Flowframe",
+                "laravel",
+                "laravel-trend"
+            ],
+            "support": {
+                "issues": "https://github.com/Flowframe/laravel-trend/issues",
+                "source": "https://github.com/Flowframe/laravel-trend/tree/v0.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/larsklopstra",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-25T11:13:23+00:00"
         },
         {
             "name": "fruitcake/php-cors",


### PR DESCRIPTION
- Introduced a new `UsersChart` widget in `app/Filament/Widgets/UsersChart.php` to display user trends over the year using a bar chart.
- Integrated the `flowframe/laravel-trend` package to facilitate trend analysis.
- Updated `composer.json` and `composer.lock` to include the new package.
- Commented out `ChoicesRelationManager` in `QuestionResource.php` and `QuestionsRelationManager` in `TestResource.php` to temporarily disable these relations.
- Removed `Widgets\AccountWidget` from the widget list in `AdminPanelProvider.php`.